### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.5.2
+        uses: actions/checkout@v3.5.3
       - uses: actions/cache@v3.3.1
         with:
           path: ~/.cache/pip
@@ -24,7 +24,7 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: Set up Python
-        uses: actions/setup-python@v4.6.0
+        uses: actions/setup-python@v4.6.1
         with:
           python-version: 3.9
 

--- a/.github/workflows/workflow_updater.yml
+++ b/.github/workflows/workflow_updater.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3.5.2
+      - uses: actions/checkout@v3.5.3
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.5.3](https://github.com/actions/checkout/releases/tag/v3.5.3)** on 2023-06-09T15:05:56Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v4.6.1](https://github.com/actions/setup-python/releases/tag/v4.6.1)** on 2023-05-24T14:12:35Z
